### PR TITLE
added to gitignore the node_modules in frontend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 
 # dependencies
 /node_modules
+/frontend/node_modules
 /.pnp
 .pnp.js
 


### PR DESCRIPTION
the issue we were having is that the node_modules directory was not in the root folder (so /node_modules), but in the frontend folder where it should be. however, in the gitignore file, this directory was not listed there (i.e. it should have said /frontend/node_modules).